### PR TITLE
EcoBosses cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>com.willfp</groupId>
 			<artifactId>EcoBosses</artifactId>
-			<version>9.33.1</version>
+			<version>9.42.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/otd/integration/EcoBossesImpl.java
+++ b/src/main/java/otd/integration/EcoBossesImpl.java
@@ -26,8 +26,8 @@ public class EcoBossesImpl {
 
 	public static void enable() {
 		try {
-			if (Class.forName("org.mineacademy.boss.BossPlugin") != null) {
-				Bukkit.getLogger().info("Loading Boss support ...");
+			if (Class.forName("com.willfp.ecobosses.EcoBossesPlugin") != null) {
+				Bukkit.getLogger().info("Loading EcoBosses support ...");
 				EcoBossesImpl.inst = new EcoBossesOTDImpl();
 				ready = true;
 			}


### PR DESCRIPTION
EcoBosses dependency cannot be picked up by the OTD during runtime. I suspect this was because EcoBosses implementation looks for the BossPlugin's class. This *should* help, but I haven't been able to compile the plugin due missing maven repo hits.